### PR TITLE
Rename GitHub workflows file from `build.yml` to `ci.yaml`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,14 +2,12 @@ name: build
 
 on:
   push:
-    branches: [ main ]
+    branches: [master]
   pull_request:
-    branches: [ main ]
+    branches: [master]
 
 jobs:
-
   build:
-
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
Just make sure that we're using the same convention as other River
projects so that things are easier to find across repos. Also:

* Rename `main` to `master`, also to maintain common convention.
* Remove build on only `master` on the `pull_request` push. Again, makes
  it the same as all other projects.