### PR TITLE
Add a changelog to the project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+- Initial release, supporting insertion through [SQLAlchemy](https://www.sqlalchemy.org/) and its underlying Postgres drivers like [psycopg2](https://pypi.org/project/psycopg2/) .


### PR DESCRIPTION
Add a changelog to the project, similar to what we already have for the
main River Go project and the Ruby client. Follows the conventional
format from keepachangelog.com.