### PR TITLE
Add help target in `Makefile` + rename `typecheck` to `type-check`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,8 +26,8 @@ jobs:
       - name: Lint
         run: rye lint
 
-      - name: Typecheck
-        run: make typecheck
+      - name: Type check
+        run: make type-check
 
       - name: Build
         run: rye build

--- a/Makefile
+++ b/Makefile
@@ -1,15 +1,23 @@
+.DEFAULT_GOAL := help
+
+# Looks at comments using ## on targets and uses them to produce a help output.
+.PHONY: help
+help: ALIGN=14
+help: ## Print this message
+	@awk -F ': .*## ' -- "/^[^':]+: .*## /"' { printf "'$$(tput bold)'%-$(ALIGN)s'$$(tput sgr0)' %s\n", $$1, $$2 }' $(MAKEFILE_LIST)
+
 .PHONY: fmt
-fmt:
+fmt: ## Autoformat code with Rye/Ruff
 	rye fmt
 
 .PHONY: lint
-lint:
+lint: ## Run linter with Rye/Ruff
 	rye lint
 
 .PHONY: test
-test:
+test: ## Run test suite with Rye/pytest
 	rye test
 
-.PHONY: typecheck
-typecheck:
+.PHONY: type-check
+type-check: ## Run type check with MyPy
 	rye run mypy -p riverqueue -p tests


### PR DESCRIPTION
Adds a help target to `Makefile` similar to what I did for Ruby which
uses comments on targets to produce a list of targets along with some
minimal documentation:

    $ make help
    help           Print this message
    fmt            Autoformat code with Rye/Ruff
    lint           Run linter with Rye/Ruff
    test           Run test suite with Rye/pytest
    type-check     Run type check with MyPy

It also runs as the default target, so `help` can be omitted:

    $ make
    help           Print this message
    fmt            Autoformat code with Rye/Ruff
    lint           Run linter with Rye/Ruff
    test           Run test suite with Rye/pytest
    type-check     Run type check with MyPy

Rename `typecheck` to `type-check` to match the same target in the Ruby
project so that we're consistent across all projects.

[1] https://github.com/riverqueue/riverqueue-ruby/pull/19