### PR TITLE
Enable job insertion on both transactions and top level pool

### DIFF
--- a/src/riverqueue/client.py
+++ b/src/riverqueue/client.py
@@ -2,7 +2,7 @@ from dataclasses import dataclass
 from datetime import datetime, timezone, timedelta
 from typing import Any, Optional, Protocol, Tuple, List, Callable
 
-from .driver import GetParams, JobInsertParams, DriverProtocol
+from .driver import GetParams, JobInsertParams, DriverProtocol, ExecutorProtocol
 from .model import InsertResult
 from .fnv import fnv1_hash
 
@@ -53,18 +53,49 @@ class Client:
     def insert(
         self, args: Args, insert_opts: Optional[InsertOpts] = None
     ) -> InsertResult:
+        for exec in self.driver.executor():
+            if not insert_opts:
+                insert_opts = InsertOpts()
+            insert_params, unique_opts = self.__make_insert_params(args, insert_opts)
+
+            def insert():
+                return InsertResult(exec.job_insert(insert_params))
+
+            return self.__check_unique_job(exec, insert_params, unique_opts, insert)
+
+        return InsertResult()  # for MyPy's benefit
+
+    def insert_tx(
+        self, tx, args: Args, insert_opts: Optional[InsertOpts] = None
+    ) -> InsertResult:
+        exec = self.driver.unwrap_executor(tx)
         if not insert_opts:
             insert_opts = InsertOpts()
         insert_params, unique_opts = self.__make_insert_params(args, insert_opts)
 
         def insert():
-            print(self.driver)
-            return InsertResult(self.driver.job_insert(insert_params))
+            return InsertResult(exec.job_insert(insert_params))
 
-        return self.__check_unique_job(insert_params, unique_opts, insert)
+        return self.__check_unique_job(exec, insert_params, unique_opts, insert)
 
     def insert_many(self, args: List[Args]) -> List[InsertResult]:
-        all_params = [
+        for exec in self.driver.executor():
+            return [
+                InsertResult(x)
+                for x in exec.job_insert_many(self.__make_insert_params_many(args))
+            ]
+
+        return []  # for MyPy's benefit
+
+    def insert_many_tx(self, tx, args: List[Args]) -> List[InsertResult]:
+        exec = self.driver.unwrap_executor(tx)
+        return [
+            InsertResult(x)
+            for x in exec.job_insert_many(self.__make_insert_params_many(args))
+        ]
+
+    def __make_insert_params_many(self, args: List[Args]) -> List[JobInsertParams]:
+        return [
             self.__make_insert_params(
                 arg.args, arg.insert_opts or InsertOpts(), is_insert_many=True
             )[0]
@@ -72,10 +103,10 @@ class Client:
             else self.__make_insert_params(arg, InsertOpts(), is_insert_many=True)[0]
             for arg in args
         ]
-        return [InsertResult(x) for x in self.driver.job_insert_many(all_params)]
 
     def __check_unique_job(
         self,
+        exec: ExecutorProtocol,
         insert_params: JobInsertParams,
         unique_opts: Optional[UniqueOpts],
         insert_func: Callable[[], InsertResult],
@@ -125,7 +156,7 @@ class Client:
         if not any_unique_opts:
             return insert_func()
 
-        with self.driver.transaction():
+        with exec.transaction():
             if self.advisory_lock_prefix is None:
                 lock_key = fnv1_hash(lock_str.encode("utf-8"), 64)
             else:
@@ -133,17 +164,21 @@ class Client:
                 lock_key = (prefix << 32) | fnv1_hash(lock_str.encode("utf-8"), 32)
 
             lock_key = self.__uint64_to_int64(lock_key)
-            self.driver.advisory_lock(lock_key)
+            exec.advisory_lock(lock_key)
 
-            existing_job = self.driver.job_get_by_kind_and_unique_properties(get_params)
+            existing_job = exec.job_get_by_kind_and_unique_properties(get_params)
             if existing_job:
                 return InsertResult(existing_job, unique_skipped_as_duplicated=True)
 
             return insert_func()
 
+        return InsertResult()  # for MyPy's benefit
+
     @staticmethod
     def __make_insert_params(
-        args: Args, insert_opts: InsertOpts, is_insert_many: bool = False
+        args: Args,
+        insert_opts: InsertOpts,
+        is_insert_many: bool = False,
     ) -> Tuple[JobInsertParams, Optional[UniqueOpts]]:
         if not hasattr(args, "kind"):
             raise Exception("args should respond to `kind`")

--- a/src/riverqueue/driver/__init__.py
+++ b/src/riverqueue/driver/__init__.py
@@ -1,5 +1,6 @@
 # Reexport for more ergonomic use in calling code.
 from .driver_protocol import (
+    ExecutorProtocol as ExecutorProtocol,
     GetParams as GetParams,
     JobInsertParams as JobInsertParams,
     DriverProtocol as DriverProtocol,

--- a/src/riverqueue/driver/driver_protocol.py
+++ b/src/riverqueue/driver/driver_protocol.py
@@ -1,4 +1,4 @@
-from contextlib import _GeneratorContextManager
+from contextlib import _GeneratorContextManager, contextmanager
 from dataclasses import dataclass, field
 from datetime import datetime
 from typing import Any, Iterator, List, Optional, Protocol
@@ -55,6 +55,7 @@ class ExecutorProtocol(Protocol):
 
 
 class DriverProtocol(Protocol):
+    @contextmanager
     def executor(self) -> Iterator[ExecutorProtocol]:
         pass
 

--- a/src/riverqueue/driver/driver_protocol.py
+++ b/src/riverqueue/driver/driver_protocol.py
@@ -1,6 +1,7 @@
+from contextlib import _GeneratorContextManager
 from dataclasses import dataclass, field
 from datetime import datetime
-from typing import Any, List, ContextManager, Optional, Protocol
+from typing import Any, Iterator, List, Optional, Protocol
 
 from ..model import Job
 
@@ -34,11 +35,11 @@ class JobInsertParams:
     finalized_at: Optional[datetime] = None
 
 
-class DriverProtocol(Protocol):
+class ExecutorProtocol(Protocol):
     def advisory_lock(self, lock: int) -> None:
         pass
 
-    def job_insert(self, insert_params: JobInsertParams) -> Optional[Job]:
+    def job_insert(self, insert_params: JobInsertParams) -> Job:
         pass
 
     def job_insert_many(self, all_params) -> List[Job]:
@@ -49,5 +50,13 @@ class DriverProtocol(Protocol):
     ) -> Optional[Job]:
         pass
 
-    def transaction(self) -> ContextManager:
+    def transaction(self) -> _GeneratorContextManager:
+        pass
+
+
+class DriverProtocol(Protocol):
+    def executor(self) -> Iterator[ExecutorProtocol]:
+        pass
+
+    def unwrap_executor(self, tx) -> ExecutorProtocol:
         pass

--- a/src/riverqueue/driver/riversqlalchemy/sql_alchemy_driver.py
+++ b/src/riverqueue/driver/riversqlalchemy/sql_alchemy_driver.py
@@ -52,6 +52,7 @@ class Driver(DriverProtocol):
     def __init__(self, conn: Connection | Engine):
         self.conn = conn
 
+    @contextmanager
     def executor(self) -> Iterator[ExecutorProtocol]:
         if isinstance(self.conn, Engine):
             with self.conn.begin() as tx:

--- a/src/riverqueue/driver/riversqlalchemy/sql_alchemy_driver.py
+++ b/src/riverqueue/driver/riversqlalchemy/sql_alchemy_driver.py
@@ -1,22 +1,29 @@
 from contextlib import contextmanager
-from typing import Optional, List, Generator
+from sqlalchemy import Engine
+from sqlalchemy.engine import Connection
+from typing import Iterator, Optional, List, Generator, cast
 
-from ...driver import DriverProtocol, GetParams, JobInsertParams
+from ...driver import DriverProtocol, ExecutorProtocol, GetParams, JobInsertParams
 from ...model import Job
 from . import river_job, pg_misc
 
 
-class Driver(DriverProtocol):
-    def __init__(self, session):
-        self.session = session
-        self.pg_misc_querier = pg_misc.Querier(session)
-        self.job_querier = river_job.Querier(session)
+class Executor(ExecutorProtocol):
+    def __init__(self, conn: Connection):
+        self.conn = conn
+        self.pg_misc_querier = pg_misc.Querier(conn)
+        self.job_querier = river_job.Querier(conn)
 
     def advisory_lock(self, key: int) -> None:
         self.pg_misc_querier.pg_advisory_xact_lock(key=key)
 
-    def job_insert(self, insert_params: JobInsertParams) -> Optional[Job]:
-        return self.job_querier.job_insert_fast(insert_params)
+    def job_insert(self, insert_params: JobInsertParams) -> Job:
+        return cast(
+            Job,
+            self.job_querier.job_insert_fast(
+                cast(river_job.JobInsertFastParams, insert_params)
+            ),
+        )
 
     def job_insert_many(self, all_params) -> List[Job]:
         raise NotImplementedError("sqlc doesn't implement copy in python yet")
@@ -24,10 +31,33 @@ class Driver(DriverProtocol):
     def job_get_by_kind_and_unique_properties(
         self, get_params: GetParams
     ) -> Optional[Job]:
-        return self.job_querier.job_get_by_kind_and_unique_properties(get_params)
+        return cast(
+            Optional[Job],
+            self.job_querier.job_get_by_kind_and_unique_properties(
+                cast(river_job.JobGetByKindAndUniquePropertiesParams, get_params)
+            ),
+        )
 
     @contextmanager
     def transaction(self) -> Generator:
-        session = self.session
-        with session.begin_nested():
-            yield
+        if self.conn.in_transaction():
+            with self.conn.begin_nested():
+                yield
+        else:
+            with self.conn.begin():
+                yield
+
+
+class Driver(DriverProtocol):
+    def __init__(self, conn: Connection | Engine):
+        self.conn = conn
+
+    def executor(self) -> Iterator[ExecutorProtocol]:
+        if isinstance(self.conn, Engine):
+            with self.conn.begin() as tx:
+                yield Executor(tx)
+        else:
+            yield Executor(self.conn)
+
+    def unwrap_executor(self, tx) -> ExecutorProtocol:
+        return Executor(tx)

--- a/tests/client_test.py
+++ b/tests/client_test.py
@@ -1,5 +1,5 @@
 from datetime import datetime, timezone
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, Mock, patch
 
 import pytest
 
@@ -17,8 +17,18 @@ def mock_driver() -> DriverProtocol:
 
 @pytest.fixture
 def mock_exec(mock_driver) -> ExecutorProtocol:
+    def mock_context_manager(val) -> Mock:
+        context_manager_mock = MagicMock()
+        context_manager_mock.__enter__.return_value = val
+        context_manager_mock.__exit__.return_value = Mock()
+        return context_manager_mock
+
+    # def mock_context_manager(val) -> Mock:
+    #     return Mock(__enter__=val, __exit__=Mock())
+
     mock_exec = MagicMock(spec=ExecutorProtocol)
-    mock_driver.executor.return_value = iter([mock_exec])
+    mock_driver.executor.return_value = mock_context_manager(mock_exec)
+
     return mock_exec
 
 

--- a/tests/client_test.py
+++ b/tests/client_test.py
@@ -4,145 +4,163 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from riverqueue import Client, InsertOpts, UniqueOpts
+from riverqueue.driver import DriverProtocol, ExecutorProtocol
+import sqlalchemy
 
 from tests.simple_args import SimpleArgs
 
 
 @pytest.fixture
-def mock_driver():
-    return MagicMock()
+def mock_driver() -> DriverProtocol:
+    return MagicMock(spec=DriverProtocol)
 
 
 @pytest.fixture
-def client(mock_driver):
+def mock_exec(mock_driver) -> ExecutorProtocol:
+    mock_exec = MagicMock(spec=ExecutorProtocol)
+    mock_driver.executor.return_value = iter([mock_exec])
+    return mock_exec
+
+
+@pytest.fixture
+def client(mock_driver) -> Client:
     return Client(mock_driver)
 
 
 @patch("datetime.datetime")
-def test_insert_with_proto_args(mock_datetime, client, mock_driver):
+def test_insert_with_only_args(mock_datetime, client, mock_exec):
     mock_datetime.now.return_value = datetime(2024, 6, 1, 12, 0, 0, tzinfo=timezone.utc)
 
-    mock_driver.job_get_by_kind_and_unique_properties.return_value = None
-    mock_driver.job_insert.return_value = "job_row"
+    mock_exec.job_get_by_kind_and_unique_properties.return_value = None
+    mock_exec.job_insert.return_value = "job_row"
 
     result = client.insert(SimpleArgs())
 
-    mock_driver.job_insert.assert_called_once()
+    mock_exec.job_insert.assert_called_once()
     assert result.job == "job_row"
 
 
 @patch("datetime.datetime")
-def test_insert_with_only_args(mock_datetime, client, mock_driver):
+def test_insert_tx(mock_datetime, mock_driver, client):
     mock_datetime.now.return_value = datetime(2024, 6, 1, 12, 0, 0, tzinfo=timezone.utc)
 
-    mock_driver.job_get_by_kind_and_unique_properties.return_value = None
-    mock_driver.job_insert.return_value = "job_row"
+    mock_exec = MagicMock(spec=ExecutorProtocol)
+    mock_exec.job_get_by_kind_and_unique_properties.return_value = None
+    mock_exec.job_insert.return_value = "job_row"
 
-    result = client.insert(SimpleArgs())
+    mock_tx = MagicMock(spec=sqlalchemy.Transaction)
 
-    mock_driver.job_insert.assert_called_once()
+    def mock_unwrap_executor(tx: sqlalchemy.Transaction):
+        assert tx == mock_tx
+        return mock_exec
+
+    mock_driver.unwrap_executor.side_effect = mock_unwrap_executor
+
+    result = client.insert_tx(mock_tx, SimpleArgs())
+
+    mock_exec.job_insert.assert_called_once()
     assert result.job == "job_row"
 
 
 @patch("datetime.datetime")
-def test_insert_with_opts(mock_datetime, client, mock_driver):
+def test_insert_with_opts(mock_datetime, client, mock_exec):
     mock_datetime.now.return_value = datetime(2024, 6, 1, 12, 0, 0, tzinfo=timezone.utc)
 
     args = SimpleArgs()
     insert_opts = InsertOpts(queue="high_priority", unique_opts=None)
 
-    mock_driver.job_get_by_kind_and_unique_properties.return_value = None
-    mock_driver.job_insert.return_value = "job_row"
+    mock_exec.job_get_by_kind_and_unique_properties.return_value = None
+    mock_exec.job_insert.return_value = "job_row"
 
     result = client.insert(args, insert_opts=insert_opts)
 
-    mock_driver.job_insert.assert_called_once()
+    mock_exec.job_insert.assert_called_once()
     assert result.job == "job_row"
 
     # Check that the InsertOpts were correctly passed to make_insert_params
-    call_args = mock_driver.job_insert.call_args[0][0]
+    call_args = mock_exec.job_insert.call_args[0][0]
     assert call_args.queue == "high_priority"
 
 
 @patch("datetime.datetime")
-def test_insert_with_unique_opts_by_args(mock_datetime, client, mock_driver):
+def test_insert_with_unique_opts_by_args(mock_datetime, client, mock_exec):
     mock_datetime.now.return_value = datetime(2024, 6, 1, 12, 0, 0, tzinfo=timezone.utc)
 
     args = SimpleArgs()
     unique_opts = UniqueOpts(by_args=True)
     insert_opts = InsertOpts(unique_opts=unique_opts)
 
-    mock_driver.job_get_by_kind_and_unique_properties.return_value = None
-    mock_driver.job_insert.return_value = "job_row"
+    mock_exec.job_get_by_kind_and_unique_properties.return_value = None
+    mock_exec.job_insert.return_value = "job_row"
 
     result = client.insert(args, insert_opts=insert_opts)
 
-    mock_driver.job_insert.assert_called_once()
+    mock_exec.job_insert.assert_called_once()
     assert result.job == "job_row"
 
     # Check that the UniqueOpts were correctly processed
-    call_args = mock_driver.job_insert.call_args[0][0]
+    call_args = mock_exec.job_insert.call_args[0][0]
     assert call_args.kind == "simple"
 
 
 @patch("datetime.datetime")
-def test_insert_with_unique_opts_by_period(mock_datetime, client, mock_driver):
+def test_insert_with_unique_opts_by_period(mock_datetime, client, mock_exec):
     mock_datetime.now.return_value = datetime(2024, 6, 1, 12, 0, 0, tzinfo=timezone.utc)
 
     args = SimpleArgs()
     unique_opts = UniqueOpts(by_period=900)
     insert_opts = InsertOpts(unique_opts=unique_opts)
 
-    mock_driver.job_get_by_kind_and_unique_properties.return_value = None
-    mock_driver.job_insert.return_value = "job_row"
+    mock_exec.job_get_by_kind_and_unique_properties.return_value = None
+    mock_exec.job_insert.return_value = "job_row"
 
     result = client.insert(args, insert_opts=insert_opts)
 
-    mock_driver.job_insert.assert_called_once()
+    mock_exec.job_insert.assert_called_once()
     assert result.job == "job_row"
 
     # Check that the UniqueOpts were correctly processed
-    call_args = mock_driver.job_insert.call_args[0][0]
+    call_args = mock_exec.job_insert.call_args[0][0]
     assert call_args.kind == "simple"
 
 
 @patch("datetime.datetime")
-def test_insert_with_unique_opts_by_queue(mock_datetime, client, mock_driver):
+def test_insert_with_unique_opts_by_queue(mock_datetime, client, mock_exec):
     mock_datetime.now.return_value = datetime(2024, 6, 1, 12, 0, 0, tzinfo=timezone.utc)
 
     args = SimpleArgs()
     unique_opts = UniqueOpts(by_queue=True)
     insert_opts = InsertOpts(unique_opts=unique_opts)
 
-    mock_driver.job_get_by_kind_and_unique_properties.return_value = None
-    mock_driver.job_insert.return_value = "job_row"
+    mock_exec.job_get_by_kind_and_unique_properties.return_value = None
+    mock_exec.job_insert.return_value = "job_row"
 
     result = client.insert(args, insert_opts=insert_opts)
 
-    mock_driver.job_insert.assert_called_once()
+    mock_exec.job_insert.assert_called_once()
     assert result.job == "job_row"
 
     # Check that the UniqueOpts were correctly processed
-    call_args = mock_driver.job_insert.call_args[0][0]
+    call_args = mock_exec.job_insert.call_args[0][0]
     assert call_args.kind == "simple"
 
 
 @patch("datetime.datetime")
-def test_insert_with_unique_opts_by_state(mock_datetime, client, mock_driver):
+def test_insert_with_unique_opts_by_state(mock_datetime, client, mock_exec):
     mock_datetime.now.return_value = datetime(2024, 6, 1, 12, 0, 0, tzinfo=timezone.utc)
 
     args = SimpleArgs()
     unique_opts = UniqueOpts(by_state=["available", "running"])
     insert_opts = InsertOpts(unique_opts=unique_opts)
 
-    mock_driver.job_get_by_kind_and_unique_properties.return_value = None
-    mock_driver.job_insert.return_value = "job_row"
+    mock_exec.job_get_by_kind_and_unique_properties.return_value = None
+    mock_exec.job_insert.return_value = "job_row"
 
     result = client.insert(args, insert_opts=insert_opts)
 
-    mock_driver.job_insert.assert_called_once()
+    mock_exec.job_insert.assert_called_once()
     assert result.job == "job_row"
 
     # Check that the UniqueOpts were correctly processed
-    call_args = mock_driver.job_insert.call_args[0][0]
+    call_args = mock_exec.job_insert.call_args[0][0]
     assert call_args.kind == "simple"


### PR DESCRIPTION
A problem with the API currently is that is that inserts on a top-level
SQLAlchemy engine aren't supported. In the test suite, the driver is
always initialized with a transaction:

    with engine.begin() as tx:
        yield riversqlalchemy.Driver(tx)

But if trying to initialize the driver with the engine itself, we'd see
failures because it doesn't support the necessary SQL execution methods
required to insert a job. Additionally, when checking for a unique job,
the driver always opens a transaction with `self.conn.begin_nested()`,
which will error unless in a transaction already.

In the Ruby client there's only a single `River#insert` method because
convention in that language is to have a lot of global stuff going on,
and the current transaction is added to local thread storage by Sequel
or ActiveRecord so that we can determine whether or not we're already in
a transaction from within the client.

SQLAlchemy is a little different. After opening a transaction, you're
expected to track the session object for perform operations in it:

    with session.begin():
        session.add(some_object())
        session.add(some_other_object())

So here I'm proposing a client API that looks a little more like the Go
API, with a pair of insert functions for `#insert` and `#insert_tx`, the
former doing an insert on the connection originally passed to driver,
and the latter doing an insert on a transaction sent as argument.

So this style of top-level insertion is now possible:

    engine = sqlalchemy.create_engine(database_url)
    client = riverqueue.Client(riversqlalchemy.Driver(engine))

    insert_res = client.insert(
        MyJobArgs(),
        insert_opts=riverqueue.InsertOpts(
            unique_opts=riverqueue.UniqueOpts(by_period=900)
        ),
    )

The client opens a new transaction on the driver's engine, and inserts
the job there.

Insertion on a particular transaction continues to be possible, and now
without having to reinitialize the client/driver:

    with engine.begin() as session:
        insert_res = client.insert_tx(
            session,
            MyJobArgs(),
            insert_opts=riverqueue.InsertOpts(
                unique_opts=riverqueue.UniqueOpts(by_period=900)
            ),
        )
        print(insert_res)