### PR TITLE
Also export `InsertResult` and `Job` models from top-level module

### DIFF
--- a/src/riverqueue/__init__.py
+++ b/src/riverqueue/__init__.py
@@ -5,3 +5,7 @@ from .client import (
     InsertOpts as InsertOpts,
     UniqueOpts as UniqueOpts,
 )
+from .model import (
+    InsertResult as InsertResult,
+    Job as Job,
+)


### PR DESCRIPTION
Follows up on #8 to also export the models `InsertResult` and `Job` from
the top-level module. These are user-facing types and it might come in
handy for projects to be able to use them.