### PR TITLE
Separate GitHub Actions job for format, lint, and type check

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -53,15 +53,6 @@ jobs:
       - name: Rye sync
         run: rye sync
 
-      - name: Format check
-        run: rye fmt --check
-
-      - name: Lint
-        run: rye lint
-
-      - name: Type check
-        run: make type-check
-
       - name: Build
         run: rye build
 
@@ -122,3 +113,25 @@ jobs:
 
       - name: Run examples
         run: rye run python3 -m examples.all
+
+  format_lint_and_type_check:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Rye
+        uses: eifinger/setup-rye@v3
+
+      - name: Rye sync
+        run: rye sync
+
+      - name: Format check
+        run: rye fmt --check
+
+      - name: Lint
+        run: rye lint
+
+      - name: Type check
+        run: make type-check


### PR DESCRIPTION
Move format, lint, and type check to a separate GitHub Actions job. This
is partly because some of these steps are a little slow so it's better
if they're running parallel, but also it's annoying to lose a whole test
run when something dumb like a lint problem fails the job early. Now, we
still see the lint failure, but get to see test failures in case we have
any of those.