### PR TITLE
Prepare release 0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.0] - 2024-07-04
+
 ### Added
 
-- Initial release, supporting insertion through [SQLAlchemy](https://www.sqlalchemy.org/) and its underlying Postgres drivers like [psycopg2](https://pypi.org/project/psycopg2/) .
+- Initial release, supporting insertion through [SQLAlchemy](https://www.sqlalchemy.org/) and its underlying Postgres drivers like [psycopg2](https://pypi.org/project/psycopg2/) or [asyncpg](https://github.com/MagicStack/asyncpg) (for async).

--- a/docs/development.md
+++ b/docs/development.md
@@ -61,3 +61,28 @@ $ rye fmt
 ```
 
 Rye uses [Ruff](https://github.com/astral-sh/ruff) under the hood for code formatting.
+
+## Publish package
+
+1. Pull existing `master` and tags, choose a version, and create a branch:
+
+    ```shell
+    git checkout master && git pull --rebase
+    export VERSION=v0.x.0
+    git checkout -b $USER-$VERSION
+    ```
+
+2. Update `CHANGELOG.md` and `pyproject.toml` to the new version number, and open a pull request. Get it reviewed and merged.
+
+3. Pull down the merged pull request, build the project (goes to `dist/`), publish it to PyPI, cut a tag for the new version, and push it to GitHub:
+
+    ```shell
+    git pull origin master
+
+    rye build
+    rye publish
+
+    git tag $VERSION
+    git push --tags
+    ```
+4. Cut a new GitHub release by visiting [new release](https://github.com/riverqueue/riverqueue-python/releases/new), selecting the new tag, and copying in the version's `CHANGELOG.md` content as the release body.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,8 @@ name = "riverqueue"
 version = "0.1.0"
 description = "Add your description here"
 authors = [
-    { name = "Eric Hauser", email = "ewhauser@gmail.com" }
+    { name = "Eric Hauser", email = "ewhauser@gmail.com" },
+    { name = "Brandur Leach", email = "brandur@brandur.org" }
 ]
 dependencies = [
     "sqlalchemy>=2.0.30",


### PR DESCRIPTION
There's still a few more changes I want to make before being fully
finished on River Python's first pass, but for now we have enough to try
a full publish to PyPI, so try for release 0.1.0