### PR TITLE
Fix description in `pyproject.toml` and add various URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix `pyproject.toml` description and add various URLs like to homepage, docs, and GitHub repositories. [PR #408](https://github.com/riverqueue/river/pull/408).
+
 ## [0.1.0] - 2024-07-04
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "riverqueue"
 version = "0.1.0"
-description = "Add your description here"
+description = "Python insert-only client for River."
 authors = [
     { name = "Eric Hauser", email = "ewhauser@gmail.com" },
     { name = "Brandur Leach", email = "brandur@brandur.org" }
@@ -15,6 +15,13 @@ requires-python = ">= 3.8"
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
+
+[project.urls]
+Homepage = "https://riverqueue.com"
+Documentation = "https://riverqueue.com/docs"
+Repository = "https://github.com/riverqueue/riverqueue-python.git"
+Issues = "https://github.com/riverqueue/riverqueue-python/issues"
+Changelog = "https://github.com/riverqueue/riverqueue-python/blob/master/CHANGELOG.md"
 
 [tool.rye]
 managed = true


### PR DESCRIPTION
Fix description in `pyproject.toml` and add a set of URLs like for the
home page and documentation that should end up in the PyPI sidebar.