### PR TITLE
Implement insert many functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Implement `insert_many` and `insert_many_tx`. [PR #22](https://github.com/riverqueue/river/pull/22).
+
 ## [0.2.0] - 2024-07-04
 
 ### Changed

--- a/examples/all.py
+++ b/examples/all.py
@@ -11,15 +11,21 @@
 import asyncio
 
 from examples import async_client_insert_example
+from examples import async_client_insert_many_example
 from examples import async_client_insert_tx_example
 from examples import client_insert_example
+from examples import client_insert_many_example
+from examples import client_insert_many_insert_opts_example
 from examples import client_insert_tx_example
 
 if __name__ == "__main__":
     asyncio.set_event_loop(asyncio.new_event_loop())
 
     asyncio.run(async_client_insert_example.example())
+    asyncio.run(async_client_insert_many_example.example())
     asyncio.run(async_client_insert_tx_example.example())
 
     client_insert_example.example()
+    client_insert_many_example.example()
+    client_insert_many_insert_opts_example.example()
     client_insert_tx_example.example()

--- a/examples/async_client_insert_many_example.py
+++ b/examples/async_client_insert_many_example.py
@@ -1,0 +1,42 @@
+#
+# Run with:
+#
+#     rye run python3 -m examples.client_insert_many_example
+#
+
+import asyncio
+from dataclasses import dataclass
+import json
+import riverqueue
+import sqlalchemy
+
+from examples.helpers import dev_database_url
+from riverqueue.driver import riversqlalchemy
+
+
+@dataclass
+class CountArgs:
+    count: int
+
+    kind: str = "sort"
+
+    def to_json(self) -> str:
+        return json.dumps({"count": self.count})
+
+
+async def example():
+    engine = sqlalchemy.ext.asyncio.create_async_engine(dev_database_url(is_async=True))
+    client = riverqueue.AsyncClient(riversqlalchemy.AsyncDriver(engine))
+
+    num_inserted = await client.insert_many(
+        [
+            CountArgs(count=1),
+            CountArgs(count=2),
+        ]
+    )
+    print(num_inserted)
+
+
+if __name__ == "__main__":
+    asyncio.set_event_loop(asyncio.new_event_loop())
+    asyncio.run(example())

--- a/examples/client_insert_many_example.py
+++ b/examples/client_insert_many_example.py
@@ -1,0 +1,40 @@
+#
+# Run with:
+#
+#     rye run python3 -m examples.client_insert_many_example
+#
+
+from dataclasses import dataclass
+import json
+import riverqueue
+import sqlalchemy
+
+from examples.helpers import dev_database_url
+from riverqueue.driver import riversqlalchemy
+
+
+@dataclass
+class CountArgs:
+    count: int
+
+    kind: str = "sort"
+
+    def to_json(self) -> str:
+        return json.dumps({"count": self.count})
+
+
+def example():
+    engine = sqlalchemy.create_engine(dev_database_url())
+    client = riverqueue.Client(riversqlalchemy.Driver(engine))
+
+    num_inserted = client.insert_many(
+        [
+            CountArgs(count=1),
+            CountArgs(count=2),
+        ]
+    )
+    print(num_inserted)
+
+
+if __name__ == "__main__":
+    example()

--- a/examples/client_insert_many_insert_opts_example.py
+++ b/examples/client_insert_many_insert_opts_example.py
@@ -1,0 +1,46 @@
+#
+# Run with:
+#
+#     rye run python3 -m examples.client_insert_many_example
+#
+
+from dataclasses import dataclass
+import json
+import riverqueue
+import sqlalchemy
+
+from examples.helpers import dev_database_url
+from riverqueue.driver import riversqlalchemy
+
+
+@dataclass
+class CountArgs:
+    count: int
+
+    kind: str = "sort"
+
+    def to_json(self) -> str:
+        return json.dumps({"count": self.count})
+
+
+def example():
+    engine = sqlalchemy.create_engine(dev_database_url())
+    client = riverqueue.Client(riversqlalchemy.Driver(engine))
+
+    num_inserted = client.insert_many(
+        [
+            riverqueue.InsertManyParams(
+                CountArgs(count=1),
+                insert_opts=riverqueue.InsertOpts(max_attempts=5),
+            ),
+            riverqueue.InsertManyParams(
+                CountArgs(count=2),
+                insert_opts=riverqueue.InsertOpts(queue="alternate_queue"),
+            ),
+        ]
+    )
+    print(num_inserted)
+
+
+if __name__ == "__main__":
+    example()

--- a/src/riverqueue/client.py
+++ b/src/riverqueue/client.py
@@ -320,7 +320,7 @@ def _make_insert_params(
         queue=insert_opts.queue or args_insert_opts.queue or QUEUE_DEFAULT,
         scheduled_at=scheduled_at and scheduled_at.astimezone(timezone.utc),
         state="scheduled" if scheduled_at else "available",
-        tags=insert_opts.tags or args_insert_opts.tags,
+        tags=insert_opts.tags or args_insert_opts.tags or [],
     )
 
     return insert_params, unique_opts

--- a/src/riverqueue/driver/driver_protocol.py
+++ b/src/riverqueue/driver/driver_protocol.py
@@ -27,16 +27,16 @@ class GetParams:
 @dataclass
 class JobInsertParams:
     kind: str
-    args: Optional[Any] = None
+    args: Any = None
     created_at: Optional[datetime] = None
     finalized_at: Optional[datetime] = None
     metadata: Optional[Any] = None
-    max_attempts: Optional[int] = field(default=25)
-    priority: Optional[int] = field(default=1)
-    queue: Optional[str] = field(default="default")
+    max_attempts: int = field(default=25)
+    priority: int = field(default=1)
+    queue: str = field(default="default")
     scheduled_at: Optional[datetime] = None
-    state: Optional[str] = field(default="available")
-    tags: Optional[List[str]] = field(default_factory=list)
+    state: str = field(default="available")
+    tags: list[str] = field(default_factory=list)
 
 
 class AsyncExecutorProtocol(Protocol):


### PR DESCRIPTION
Here, finish the implementations on `#insert_many` and `#insert_many_tx`,
which were previously marked as not yet finished. The Python plugin for
sqlc doesn't implement `copyfrom`, so we instead fall back on an
alternative approach from an experimental `database/sql` branch I have,
which implements an insert many operation using a combination of Postgres
arrays and `unnest`.

We remove some `Optional` annotations on `JobInsertParams` for properties
that are always set by the client. (Necessary to make MyPy's checks pass
properly.)