### PR TITLE
Validate format of tags to be max 255 characters and with certain characters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,29 +7,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Tags are now limited to 255 characters in length, and should match the regex `\A[\w][\w\-]+[\w]\z` (importantly, they can't contain commas). [PR #23](https://github.com/riverqueue/riverqueue-python/pull/23).
+
 ## [0.3.0] - 2024-07-04
 
 ### Added
 
-- Implement `insert_many` and `insert_many_tx`. [PR #22](https://github.com/riverqueue/river/pull/22).
+- Implement `insert_many` and `insert_many_tx`. [PR #22](https://github.com/riverqueue/riverqueue-python/pull/22).
 
 ## [0.2.0] - 2024-07-04
 
 ### Changed
 
-- Rename `Args` to `JobArgs` and add `JobArgsWithInsertOpts` protocol. [PR #20](https://github.com/riverqueue/river/pull/20).
+- Rename `Args` to `JobArgs` and add `JobArgsWithInsertOpts` protocol. [PR #20](https://github.com/riverqueue/riverqueue-python/pull/20).
 
 ## [0.1.2] - 2024-07-04
 
 ### Changed
 
-- Add usage instructions README, add job state constants, and change return value of `insert_many()` and `insert_many_tx()` to an integer instead of a list of jobs. [PR #19](https://github.com/riverqueue/river/pull/19).
+- Add usage instructions README, add job state constants, and change return value of `insert_many()` and `insert_many_tx()` to an integer instead of a list of jobs. [PR #19](https://github.com/riverqueue/riverqueue-python/pull/19).
 
 ## [0.1.1] - 2024-07-04
 
 ### Fixed
 
-- Fix `pyproject.toml` description and add various URLs like to homepage, docs, and GitHub repositories. [PR #18](https://github.com/riverqueue/river/pull/18).
+- Fix `pyproject.toml` description and add various URLs like to homepage, docs, and GitHub repositories. [PR #18](https://github.com/riverqueue/riverqueue-python/pull/18).
 
 ## [0.1.0] - 2024-07-04
 

--- a/tests/client_test.py
+++ b/tests/client_test.py
@@ -259,6 +259,26 @@ def test_insert_to_json_none_error(client):
     assert "args should return non-nil from `to_json`" == str(ex.value)
 
 
+def test_tag_validation(client):
+    client.insert(
+        SimpleArgs(), insert_opts=InsertOpts(tags=["foo", "bar", "baz", "foo-bar-baz"])
+    )
+
+    with pytest.raises(AssertionError) as ex:
+        client.insert(SimpleArgs(), insert_opts=InsertOpts(tags=["commas,bad"]))
+    assert (
+        "tags should be less than 255 characters in length and match regex \A[\w][\w\-]+[\w]\Z"
+        == str(ex.value)
+    )
+
+    with pytest.raises(AssertionError) as ex:
+        client.insert(SimpleArgs(), insert_opts=InsertOpts(tags=["a" * 256]))
+    assert (
+        "tags should be less than 255 characters in length and match regex \A[\w][\w\-]+[\w]\Z"
+        == str(ex.value)
+    )
+
+
 def test_check_advisory_lock_prefix_bounds():
     Client(mock_driver, advisory_lock_prefix=123)
 


### PR DESCRIPTION
Match up tag validations that came in with the main project here [1].
The multi insertion queries use commas to split tags during batch
inserts, so it's important that incoming tags don't have comms of their
own.

[1] https://github.com/riverqueue/river/pull/351