### PR TITLE
Use real enum for `JobState` instead of many constant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Use real enum for `JobState` instead of many constant. This is a breaking change, but the job state constants have existed for only a short time. [PR #25](https://github.com/riverqueue/riverqueue-python/pull/25).
+
 ## [0.4.0] - 2024-07-05
 
 ### Changed

--- a/src/riverqueue/__init__.py
+++ b/src/riverqueue/__init__.py
@@ -1,15 +1,9 @@
 # Reexport for more ergonomic use in calling code.
 from .client import (
-    JOB_STATE_AVAILABLE as JOB_STATE_AVAILABLE,
-    JOB_STATE_CANCELLED as JOB_STATE_CANCELLED,
-    JOB_STATE_COMPLETED as JOB_STATE_COMPLETED,
-    JOB_STATE_DISCARDED as JOB_STATE_DISCARDED,
-    JOB_STATE_RETRYABLE as JOB_STATE_RETRYABLE,
-    JOB_STATE_RUNNING as JOB_STATE_RUNNING,
-    JOB_STATE_SCHEDULED as JOB_STATE_SCHEDULED,
     AsyncClient as AsyncClient,
     JobArgs as JobArgs,
     JobArgsWithInsertOpts as JobArgsWithInsertOpts,
+    JobState as JobState,
     Client as Client,
     InsertManyParams as InsertManyParams,
     InsertOpts as InsertOpts,

--- a/src/riverqueue/client.py
+++ b/src/riverqueue/client.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass
 from datetime import datetime, timezone, timedelta
+from enum import Enum
 import re
 from typing import (
     Any,
@@ -18,23 +19,27 @@ from .driver.driver_protocol import AsyncDriverProtocol, AsyncExecutorProtocol
 from .model import InsertResult
 from .fnv import fnv1_hash
 
-JOB_STATE_AVAILABLE = "available"
-JOB_STATE_CANCELLED = "cancelled"
-JOB_STATE_COMPLETED = "completed"
-JOB_STATE_DISCARDED = "discarded"
-JOB_STATE_RETRYABLE = "retryable"
-JOB_STATE_RUNNING = "running"
-JOB_STATE_SCHEDULED = "scheduled"
 
-MAX_ATTEMPTS_DEFAULT = 25
-PRIORITY_DEFAULT = 1
-QUEUE_DEFAULT = "default"
-UNIQUE_STATES_DEFAULT = [
-    JOB_STATE_AVAILABLE,
-    JOB_STATE_COMPLETED,
-    JOB_STATE_RUNNING,
-    JOB_STATE_RETRYABLE,
-    JOB_STATE_SCHEDULED,
+class JobState(str, Enum):
+    AVAILABLE = "available"
+    CANCELLED = "cancelled"
+    COMPLETED = "completed"
+    DISCARDED = "discarded"
+    PENDING = "pending"
+    RETRYABLE = "retryable"
+    RUNNING = "running"
+    SCHEDULED = "scheduled"
+
+
+MAX_ATTEMPTS_DEFAULT: int = 25
+PRIORITY_DEFAULT: int = 1
+QUEUE_DEFAULT: str = "default"
+UNIQUE_STATES_DEFAULT: list[str] = [
+    JobState.AVAILABLE,
+    JobState.COMPLETED,
+    JobState.RUNNING,
+    JobState.RETRYABLE,
+    JobState.SCHEDULED,
 ]
 
 
@@ -351,7 +356,7 @@ def _uint64_to_int64(uint64):
     return (uint64 + (1 << 63)) % (1 << 64) - (1 << 63)
 
 
-tag_re = re.compile("\A[\w][\w\-]+[\w]\Z")
+tag_re = re.compile(r"\A[\w][\w\-]+[\w]\Z")
 
 
 def _validate_tags(tags: list[str]) -> list[str]:


### PR DESCRIPTION
When I put in job state constants in #19, I didn't think to check first
whether there was a concept of real enums in Python. Turns out there is,
and we should use one instead of a whole bunch of raw constants.

This is a breaking change, but the job states have existed for so little
time that I doubt it'll break anybody, so it's worth doing it in this
instance.

And a few other small changes:

* Add typing to all exported constants.

* Fix an "invalid escape sequence" in the tag validation regex stemming
  from the `\A` in it by making the string a "raw string" with `r`.