### PR TITLE
Give `riverqueue.Job` fully defined properties + timestamps as UTC

### DIFF
--- a/src/riverqueue/__init__.py
+++ b/src/riverqueue/__init__.py
@@ -3,7 +3,6 @@ from .client import (
     AsyncClient as AsyncClient,
     JobArgs as JobArgs,
     JobArgsWithInsertOpts as JobArgsWithInsertOpts,
-    JobState as JobState,
     Client as Client,
     InsertManyParams as InsertManyParams,
     InsertOpts as InsertOpts,
@@ -12,4 +11,5 @@ from .client import (
 from .model import (
     InsertResult as InsertResult,
     Job as Job,
+    JobState as JobState,
 )

--- a/src/riverqueue/client.py
+++ b/src/riverqueue/client.py
@@ -1,6 +1,5 @@
 from dataclasses import dataclass
 from datetime import datetime, timezone, timedelta
-from enum import Enum
 import re
 from typing import (
     Any,
@@ -16,19 +15,8 @@ from typing import (
 
 from .driver import GetParams, JobInsertParams, DriverProtocol, ExecutorProtocol
 from .driver.driver_protocol import AsyncDriverProtocol, AsyncExecutorProtocol
-from .model import InsertResult
+from .model import InsertResult, JobState
 from .fnv import fnv1_hash
-
-
-class JobState(str, Enum):
-    AVAILABLE = "available"
-    CANCELLED = "cancelled"
-    COMPLETED = "completed"
-    DISCARDED = "discarded"
-    PENDING = "pending"
-    RETRYABLE = "retryable"
-    RUNNING = "running"
-    SCHEDULED = "scheduled"
 
 
 MAX_ATTEMPTS_DEFAULT: int = 25

--- a/src/riverqueue/model.py
+++ b/src/riverqueue/model.py
@@ -1,13 +1,41 @@
 from dataclasses import dataclass, field
-from typing import Optional
+import datetime
+from enum import Enum
+from typing import Any, Optional
+
+
+class JobState(str, Enum):
+    AVAILABLE = "available"
+    CANCELLED = "cancelled"
+    COMPLETED = "completed"
+    DISCARDED = "discarded"
+    PENDING = "pending"
+    RETRYABLE = "retryable"
+    RUNNING = "running"
+    SCHEDULED = "scheduled"
 
 
 @dataclass
 class InsertResult:
-    job: Optional["Job"] = field(default=None)
+    job: "Job"
     unique_skipped_as_duplicated: bool = field(default=False)
 
 
 @dataclass
 class Job:
-    pass
+    id: int
+    args: dict[str, Any]
+    attempt: int
+    attempted_at: Optional[datetime.datetime]
+    attempted_by: Optional[list[str]]
+    created_at: datetime.datetime
+    errors: Optional[list[Any]]
+    finalized_at: Optional[datetime.datetime]
+    kind: str
+    max_attempts: int
+    metadata: dict[str, Any]
+    priority: int
+    queue: str
+    state: JobState
+    scheduled_at: datetime.datetime
+    tags: list[str]

--- a/tests/client_test.py
+++ b/tests/client_test.py
@@ -267,14 +267,14 @@ def test_tag_validation(client):
     with pytest.raises(AssertionError) as ex:
         client.insert(SimpleArgs(), insert_opts=InsertOpts(tags=["commas,bad"]))
     assert (
-        "tags should be less than 255 characters in length and match regex \A[\w][\w\-]+[\w]\Z"
+        r"tags should be less than 255 characters in length and match regex \A[\w][\w\-]+[\w]\Z"
         == str(ex.value)
     )
 
     with pytest.raises(AssertionError) as ex:
         client.insert(SimpleArgs(), insert_opts=InsertOpts(tags=["a" * 256]))
     assert (
-        "tags should be less than 255 characters in length and match regex \A[\w][\w\-]+[\w]\Z"
+        r"tags should be less than 255 characters in length and match regex \A[\w][\w\-]+[\w]\Z"
         == str(ex.value)
     )
 


### PR DESCRIPTION
Previously, the internal sqlc `RiverJob` row was fully typed by virtue
of being generated by sqlc, but the `riverqueue.Job` type was undefined,
with typechecks working by using a `cast`.

Here, give `riverqueue.Job` a full set of defined properties. This is
better for things like conveying type information and autocomplete, but
has a few other side benefits:

* Make sure to return all timestamps as UTC. Previously, they'd be in
  whatever your local timezone is.

* Give some fields like `args`, `metadata`, and `state` better types
  (the first two were previously `Any`).

Lastly, modify `InsertResult` somewhat to make `job` non-optional since
it's always returned, even if insert was skipped, because if it was we
look it up via select query.