### PR TITLE
Test that checks that `AttemptError` can round trip properly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `riverqueue.AttemptError` can now round trip to and from JSON properly, including its `at` timestamp. [PR #31](https://github.com/riverqueue/riverqueue-python/pull/31).
+
 ## [0.6.0] - 2024-07-06
 
 ### Added

--- a/src/riverqueue/driver/riversqlalchemy/dbsqlc/river_job.sql
+++ b/src/riverqueue/driver/riversqlalchemy/dbsqlc/river_job.sql
@@ -104,3 +104,36 @@ INSERT INTO river_job(
     -- Had trouble getting multi-dimensional arrays to play nicely with sqlc,
     -- but it might be possible. For now, join tags into a single string.
     string_to_array(unnest(@tags::text[]), ',');
+
+-- name: JobInsertFull :one
+INSERT INTO river_job(
+    args,
+    attempt,
+    attempted_at,
+    created_at,
+    errors,
+    finalized_at,
+    kind,
+    max_attempts,
+    metadata,
+    priority,
+    queue,
+    scheduled_at,
+    state,
+    tags
+) VALUES (
+    @args::jsonb,
+    coalesce(@attempt::smallint, 0),
+    @attempted_at,
+    coalesce(sqlc.narg('created_at')::timestamptz, now()),
+    @errors::jsonb[],
+    @finalized_at,
+    @kind::text,
+    @max_attempts::smallint,
+    coalesce(@metadata::jsonb, '{}'),
+    @priority::smallint,
+    @queue::text,
+    coalesce(sqlc.narg('scheduled_at')::timestamptz, now()),
+    @state::river_job_state,
+    coalesce(@tags::varchar(255)[], '{}')
+) RETURNING *;


### PR DESCRIPTION
Follows up #27 to add a more elaborate test that checks that non-default
job properties can unmarshal to `Job` property including `errors, which
includes `AttemptError`. It turned out that of course this wasn't
working properly.