### PR TITLE
Make typing on `UniqueOpts.by_state` true `JobState` enums instead of strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- `UniqueOpts.by_state` now has the stronger type of `list[JobState]` (the enum) instead of `list[str]`. [PR #32](https://github.com/riverqueue/riverqueue-python/pull/32).
+
 ## [0.6.1] - 2024-07-06
 
 ### Fixed

--- a/src/riverqueue/client.py
+++ b/src/riverqueue/client.py
@@ -8,6 +8,7 @@ from typing import (
     Tuple,
     List,
     Callable,
+    cast,
     runtime_checkable,
 )
 
@@ -644,7 +645,7 @@ def _build_unique_get_params_and_lock_key(
     if unique_opts.by_state:
         any_unique_opts = True
         get_params.by_state = True
-        get_params.state = unique_opts.by_state
+        get_params.state = cast(list[str], unique_opts.by_state)
         lock_str += f"&state={','.join(unique_opts.by_state)}"
     else:
         get_params.state = UNIQUE_STATES_DEFAULT

--- a/src/riverqueue/insert_opts.py
+++ b/src/riverqueue/insert_opts.py
@@ -2,6 +2,8 @@ from dataclasses import dataclass
 from datetime import datetime
 from typing import Any, Literal, Optional
 
+from riverqueue.job import JobState
+
 
 @dataclass
 class InsertOpts:
@@ -119,7 +121,7 @@ class UniqueOpts:
     enabled, uniqueness will be enforced for a kind across all queues.
     """
 
-    by_state: Optional[list[str]] = None
+    by_state: Optional[list[JobState]] = None
     """
     Indicates that uniqueness should be enforced across any of the states in
     the given set. For example, if the given states were `(scheduled,

--- a/tests/driver/riversqlalchemy/sqlalchemy_driver_test.py
+++ b/tests/driver/riversqlalchemy/sqlalchemy_driver_test.py
@@ -180,7 +180,7 @@ class TestAsyncClient:
     @pytest.mark.asyncio
     async def test_insert_with_unique_opts_by_state(self, client, simple_args):
         insert_opts = InsertOpts(
-            unique_opts=UniqueOpts(by_state=["available", "running"])
+            unique_opts=UniqueOpts(by_state=[JobState.AVAILABLE, JobState.RUNNING])
         )
         insert_res = await client.insert(simple_args, insert_opts=insert_opts)
         assert insert_res.job
@@ -299,7 +299,7 @@ class TestSyncClient:
 
     def test_insert_with_unique_opts_by_state(self, client, simple_args):
         insert_opts = InsertOpts(
-            unique_opts=UniqueOpts(by_state=["available", "running"])
+            unique_opts=UniqueOpts(by_state=[JobState.AVAILABLE, JobState.RUNNING])
         )
         insert_res = client.insert(simple_args, insert_opts=insert_opts)
         assert insert_res.job


### PR DESCRIPTION
Make the typing on `UniqueOpts.by_state` strong by making it a list of
`JobState` enums instead of a list of strings. Change usages in the test
suite over to enums instead of strings.