### PR TITLE
Fix python syntax in README examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,8 +65,8 @@ insert_res = client.insert(
     insert_opts=riverqueue.InsertOpts(
         max_attempts=17,
         priority=3,
-        queue: "my_queue",
-        tags: ["custom"]
+        queue="my_queue",
+        tags=["custom"]
     ),
 )
 ```
@@ -80,10 +80,10 @@ insert_res = client.insert(
     SortArgs(strings=["whale", "tiger", "bear"]),
     insert_opts=riverqueue.InsertOpts(
         unique_opts=riverqueue.UniqueOpts(
-            by_args: True,
+            by_args=True,
             by_period=15*60,
-            by_queue: True,
-            by_state: [riverqueue.JobState.AVAILABLE]
+            by_queue=True,
+            by_state=[riverqueue.JobState.AVAILABLE]
         )
     ),
 )
@@ -100,7 +100,7 @@ insert_res.unique_skipped_as_duplicated
 Unique job insertion takes a Postgres advisory lock to make sure that its uniqueness check still works even if two conflicting insert operations are occurring in parallel. Postgres advisory locks share a global 64-bit namespace, which is a large enough space that it's unlikely for two advisory locks to ever conflict, but to _guarantee_ that River's advisory locks never interfere with an application's, River can be configured with a 32-bit advisory lock prefix which it will use for all its locks:
 
 ```python
-client = riverqueue.Client(riversqlalchemy.Driver(engine), advisory_lock_prefix: 123456)
+client = riverqueue.Client(riversqlalchemy.Driver(engine), advisory_lock_prefix=123456)
 ```
 
 Doing so has the downside of leaving only 32 bits for River's locks (64 bits total - 32-bit prefix), making them somewhat more likely to conflict with each other.
@@ -111,8 +111,8 @@ Use `#insert_many` to bulk insert jobs as a single operation for improved effici
 
 ```python
 num_inserted = client.insert_many([
-    SimpleArgs(job_num: 1),
-    SimpleArgs(job_num: 2)
+    SimpleArgs(job_num=1),
+    SimpleArgs(job_num=2)
 ])
 ```
 
@@ -120,8 +120,8 @@ Or with `InsertManyParams`, which may include insertion options:
 
 ```python
 num_inserted = client.insert_many([
-    InsertManyParams(args=SimpleArgs.new(job_num: 1), insert_opts=riverqueue.InsertOpts.new(max_attempts=5)),
-    InsertManyParams(args=SimpleArgs.new(job_num: 2), insert_opts=riverqueue.InsertOpts.new(queue="high_priority"))
+    InsertManyParams(args=SimpleArgs(job_num=1), insert_opts=riverqueue.InsertOpts(max_attempts=5)),
+    InsertManyParams(args=SimpleArgs(job_num=2), insert_opts=riverqueue.InsertOpts(queue="high_priority"))
 ])
 ```
 


### PR DESCRIPTION
Fixing a few typos with kwargs & new