### PR TITLE
Prepare release 0.6.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.3] - 2024-07-08
+
+### Fixed
+
+- Various Python syntax fixes in README examples. [PR #34](https://github.com/riverqueue/riverqueue-python/pull/34).
+
 ## [0.6.2] - 2024-07-06
 
 ### Changed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "riverqueue"
-version = "0.6.2"
+version = "0.6.3"
 description = "Python insert-only client for River."
 authors = [
     { name = "Eric Hauser", email = "ewhauser@gmail.com" },


### PR DESCRIPTION
Prepare release 0.6.3 which contains various fixes for Python syntax in
README examples [1].

[1] https://github.com/riverqueue/riverqueue-python/pull/34