### PR TITLE
Prepare release v0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.0] - 2024-07-30
+
 ### Changed
 
 - Now compatible with "fast path" unique job insertion that uses a unique index instead of advisory lock and fetch [as introduced in River #451](https://github.com/riverqueue/river/pull/451). [PR #36](https://github.com/riverqueue/riverqueue-python/pull/36).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "riverqueue"
-version = "0.6.3"
+version = "0.7.0"
 description = "Python insert-only client for River."
 authors = [
     { name = "Eric Hauser", email = "ewhauser@gmail.com" },


### PR DESCRIPTION
Prepare v0.7.0, containing largely an implementation for fast path
unique job insertion as implemented in #36.