### PR TITLE
Don't try to mock context manager; use a simple class instead

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -63,7 +63,7 @@ jobs:
         run: psql --echo-errors --quiet -c '\timing off' -c "CREATE DATABASE ${TEST_DATABASE_NAME};" ${ADMIN_DATABASE_URL}
 
       - name: river migrate-up
-        run: river migrate-up --database-url "$TEST_DATABASE_URL"
+        run: river migrate-up --database-url "$TEST_DATABASE_URL" --max-steps 5 # temporarily include max steps so tests can pass with unique fixes
 
       - name: Test
         run: rye test
@@ -109,7 +109,7 @@ jobs:
         run: psql --echo-errors --quiet -c '\timing off' -c "CREATE DATABASE ${DATABASE_NAME};" ${ADMIN_DATABASE_URL}
 
       - name: river migrate-up
-        run: river migrate-up --database-url "$DATABASE_URL"
+        run: river migrate-up --database-url "$DATABASE_URL" --max-steps 5 # temporarily include max steps so tests can pass with unique fixes
 
       - name: Run examples
         run: rye run python3 -m examples.all


### PR DESCRIPTION
This one's related to #38. It turns out that while trying to mock a
context manager kind of works, it will do the wrong thing in edge cases
like when an exception is thrown from inside a `with` block, silently
swallowing it and causing a return that's completely wrong.

There may be some way to fix the mock to make it do the right thing, but
instead of getting fancier with these mocks that are already awful,
instead repair the problem by defining a plain class that implements
context manager and just use that.